### PR TITLE
Manifests can now be updated (with version-checking to prevent unnecessary updates)

### DIFF
--- a/lib/restiny.rb
+++ b/lib/restiny.rb
@@ -49,13 +49,23 @@ module Restiny
   # Manifest methods
 
   def download_manifest(locale = "en")
+
+    manifest_path, version = get_manifest_info()
+
+    Manifest.new(Manifest.download(BUNGIE_URL + manifest_path), version)
+  end
+
+  def get_manifest_info
     response = get("Destiny2/Manifest/")
 
     manifest_path = response.dig("mobileWorldContentPaths", locale)
     raise Restiny::ResponseError.new("Unable to determine manifest URL") if manifest_path.nil?
 
-    Manifest.download(BUNGIE_URL + manifest_path)
+    version = response.dig("version")
+
+    return manifest_path, version
   end
+
 
   # Profile methods
 

--- a/lib/restiny.rb
+++ b/lib/restiny.rb
@@ -52,10 +52,10 @@ module Restiny
 
     manifest_path, version = get_manifest_info(locale)
 
-    Manifest.new(Manifest.download(BUNGIE_URL + manifest_path), version)
+    Manifest.new(Manifest.download(BUNGIE_URL + manifest_path), version, locale)
   end
 
-  def get_manifest_info(locale)
+  def get_manifest_info(locale = "en")
     response = get("Destiny2/Manifest/")
 
     manifest_path = response.dig("mobileWorldContentPaths", locale)

--- a/lib/restiny.rb
+++ b/lib/restiny.rb
@@ -50,12 +50,12 @@ module Restiny
 
   def download_manifest(locale = "en")
 
-    manifest_path, version = get_manifest_info()
+    manifest_path, version = get_manifest_info(locale)
 
     Manifest.new(Manifest.download(BUNGIE_URL + manifest_path), version)
   end
 
-  def get_manifest_info
+  def get_manifest_info(locale)
     response = get("Destiny2/Manifest/")
 
     manifest_path = response.dig("mobileWorldContentPaths", locale)

--- a/lib/restiny/manifest.rb
+++ b/lib/restiny/manifest.rb
@@ -104,16 +104,16 @@ module Restiny
       Restiny.get("Destiny2/Manifest/").dig("version")
     end
 
-    def initialize(file_path, version, locale)
+    def initialize(file_path, version, locale = "en")
       @locale = locale
-      new_data!(file_path, version)
+      new_data(file_path, version)
     end
 
     def up_to_date?
       @version == self.remote_manifest_version
     end  
 
-    def new_data!(file_path, version)         
+    def new_data(file_path, version)         
       if file_path.empty? || !File.exist?(file_path) || !File.file?(file_path)
         raise Restiny::InvalidParamsError.new("You must provide a valid path for the manifest file")
       end
@@ -133,7 +133,7 @@ module Restiny
       unless up_to_date?
         manifest_path, version = Restiny.get_manifest_info(@locale)
     
-        new_data!(Manifest.download(BUNGIE_URL + manifest_path), version)
+        new_data(Manifest.download(BUNGIE_URL + manifest_path), version)
       end
     end
 

--- a/lib/restiny/manifest.rb
+++ b/lib/restiny/manifest.rb
@@ -104,7 +104,8 @@ module Restiny
       Restiny.get("Destiny2/Manifest/").dig("version")
     end
 
-    def initialize(file_path, version)
+    def initialize(file_path, version, locale)
+      @locale = locale
       new_data!(file_path, version)
     end
 
@@ -112,7 +113,7 @@ module Restiny
       @version == self.remote_manifest_version
     end  
 
-    def new_data!(file_path)         
+    def new_data!(file_path, version)         
       if file_path.empty? || !File.exist?(file_path) || !File.file?(file_path)
         raise Restiny::InvalidParamsError.new("You must provide a valid path for the manifest file")
       end
@@ -130,7 +131,7 @@ module Restiny
 
     def update
       unless up_to_date?
-        manifest_path, version = Restiny.get_manifest_info
+        manifest_path, version = Restiny.get_manifest_info(@locale)
     
         new_data!(Manifest.download(BUNGIE_URL + manifest_path), version)
       end

--- a/lib/restiny/version.rb
+++ b/lib/restiny/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Restiny
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
Existing Manifests, when updated, will default to English as they don't have a tracked locale. They'll also actually update the first time, even if up to date, as they have no tracked version.